### PR TITLE
feat: add check-in enabled toggle for tasks

### DIFF
--- a/drizzle/20251231180641_equal_miek/migration.sql
+++ b/drizzle/20251231180641_equal_miek/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tasks` ADD `check_in_enabled` integer DEFAULT false NOT NULL;

--- a/drizzle/20251231180641_equal_miek/snapshot.json
+++ b/drizzle/20251231180641_equal_miek/snapshot.json
@@ -1,0 +1,437 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "2ce9575b-1e70-4c3e-84b5-e3f030e3f13a",
+  "prevIds": [
+    "64133f71-5865-49d6-8976-c31d27e31def"
+  ],
+  "ddl": [
+    {
+      "name": "daily_completions",
+      "entityType": "tables"
+    },
+    {
+      "name": "sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "tasks",
+      "entityType": "tables"
+    },
+    {
+      "name": "users",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "daily_completions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "task_id",
+      "entityType": "columns",
+      "table": "daily_completions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_date",
+      "entityType": "columns",
+      "table": "daily_completions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_days",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_value",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "current_value",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "unit",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "check_in_enabled",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "twitch_id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "avatar_url",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'en'",
+      "generated": null,
+      "name": "language",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "columns": [
+        "task_id"
+      ],
+      "tableTo": "tasks",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_daily_completions_task_id_tasks_id_fk",
+      "entityType": "fks",
+      "table": "daily_completions"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sessions_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_tasks_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "tasks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "daily_completions_pk",
+      "table": "daily_completions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pk",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "tasks_pk",
+      "table": "tasks",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pk",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "task_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "daily_completions_task_id_idx",
+      "entityType": "indexes",
+      "table": "daily_completions"
+    },
+    {
+      "columns": [
+        {
+          "value": "task_id",
+          "isExpression": false
+        },
+        {
+          "value": "completed_date",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "daily_completions_task_date_idx",
+      "entityType": "indexes",
+      "table": "daily_completions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "sessions_user_id_idx",
+      "entityType": "indexes",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "tasks_user_id_idx",
+      "entityType": "indexes",
+      "table": "tasks"
+    },
+    {
+      "columns": [
+        "twitch_id"
+      ],
+      "nameExplicit": false,
+      "name": "users_twitch_id_unique",
+      "entityType": "uniques",
+      "table": "users"
+    }
+  ],
+  "renames": []
+}

--- a/drizzle/migrations/.converted
+++ b/drizzle/migrations/.converted
@@ -2,3 +2,4 @@
 20251230182310_chubby_mongoose
 20251230202707_clean_gravity
 20251230220014_mute_iron_lad
+20251231180641_equal_miek

--- a/drizzle/migrations/0005_equal-miek.sql
+++ b/drizzle/migrations/0005_equal-miek.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tasks` ADD `check_in_enabled` integer DEFAULT false NOT NULL;

--- a/src/components/TaskCard.vue
+++ b/src/components/TaskCard.vue
@@ -149,6 +149,19 @@
                 />
               </div>
             </template>
+
+            <!-- Check-in control (common for all task types) -->
+            <div :class="$style.checkInField">
+              <label :class="$style.checkboxLabel">
+                <input
+                  v-model="editForm.checkInEnabled"
+                  type="checkbox"
+                  :class="$style.checkbox"
+                />
+                <span>{{ $t('taskForm.checkInEnabled') }}</span>
+              </label>
+              <span :class="$style.checkInHint">{{ $t('taskForm.checkInEnabledHint') }}</span>
+            </div>
           </div>
 
           <div :class="$style.modalActions">
@@ -202,6 +215,7 @@
     unit: '',
     completedDates: [] as string[],
     newDate: '',
+    checkInEnabled: false,
   })
 
   const progress = computed(() => getTaskProgress(props.task))
@@ -277,6 +291,7 @@
     editForm.title = props.task.title
     editForm.description = props.task.description ?? ''
     editForm.newDate = ''
+    editForm.checkInEnabled = props.task.checkInEnabled
 
     if (isDailyTask(props.task)) {
       editForm.targetDays = props.task.targetDays
@@ -314,6 +329,7 @@
         description: editForm.description.trim() || undefined,
         targetDays: editForm.targetDays,
         completedDates: editForm.completedDates,
+        checkInEnabled: editForm.checkInEnabled,
       } satisfies DailyTask
     } else if (isProgressTask(props.task)) {
       updatedTask = {
@@ -323,12 +339,14 @@
         currentValue: editForm.currentValue,
         targetValue: editForm.targetValue,
         unit: editForm.unit.trim(),
+        checkInEnabled: editForm.checkInEnabled,
       } satisfies ProgressTask
     } else {
       updatedTask = {
         ...props.task,
         title: editForm.title.trim(),
         description: editForm.description.trim() || undefined,
+        checkInEnabled: editForm.checkInEnabled,
       }
     }
 
@@ -677,5 +695,35 @@
   .saveBtn:disabled {
     opacity: 0.6;
     cursor: not-allowed;
+  }
+
+  .checkInField {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 12px;
+    background: var(--color-hover);
+    border-radius: 8px;
+    margin-top: 8px;
+  }
+
+  .checkboxLabel {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+  }
+
+  .checkbox {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--color-primary);
+    cursor: pointer;
+  }
+
+  .checkInHint {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    padding-left: 28px;
   }
 </style>

--- a/src/components/TaskForm.vue
+++ b/src/components/TaskForm.vue
@@ -97,6 +97,18 @@
       </div>
     </template>
 
+    <div :class="$style.checkInField">
+      <label :class="$style.checkboxLabel">
+        <input
+          v-model="checkInEnabled"
+          type="checkbox"
+          :class="$style.checkbox"
+        />
+        <span :class="$style.checkboxText">{{ $t('taskForm.checkInEnabled') }}</span>
+      </label>
+      <span :class="$style.checkInHint">{{ $t('taskForm.checkInEnabledHint') }}</span>
+    </div>
+
     <div :class="$style.actions">
       <button
         type="button"
@@ -131,6 +143,7 @@
   const targetDays = ref(30)
   const targetValue = ref(1000)
   const unit = ref('')
+  const checkInEnabled = ref(false)
 
   const isValid = computed(() => {
     if (!title.value.trim()) {return false}
@@ -146,6 +159,7 @@
       title: title.value.trim(),
       description: description.value.trim() || undefined,
       type: taskType.value,
+      checkInEnabled: checkInEnabled.value,
     }
 
     if (taskType.value === 'daily') {
@@ -283,5 +297,41 @@
   .submitBtn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  .checkInField {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 12px 16px;
+    background: var(--color-surface);
+    border: 2px solid var(--color-border);
+    border-radius: 8px;
+  }
+
+  .checkboxLabel {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+  }
+
+  .checkbox {
+    width: 20px;
+    height: 20px;
+    accent-color: var(--color-primary);
+    cursor: pointer;
+  }
+
+  .checkboxText {
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+
+  .checkInHint {
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+    padding-left: 30px;
   }
 </style>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -36,6 +36,8 @@ const enLocale = {
     targetValue: 'Target value',
     unit: 'Unit of measurement',
     unitPlaceholder: 'steps, pages, km...',
+    checkInEnabled: 'Include in check-in',
+    checkInEnabledHint: 'Task will appear during daily check-in',
   },
   taskCard: {
     menuLabel: 'Task menu',

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -36,6 +36,8 @@ const ruLocale = {
     targetValue: 'Целевое значение',
     unit: 'Единица измерения',
     unitPlaceholder: 'шагов, страниц, км...',
+    checkInEnabled: 'Включить в check-in',
+    checkInEnabledHint: 'Задача будет появляться при ежедневном чекине',
   },
   taskCard: {
     menuLabel: 'Меню задачи',

--- a/src/models/__tests__/task.test.ts
+++ b/src/models/__tests__/task.test.ts
@@ -10,6 +10,7 @@ describe('Task Types', () => {
       targetDays: 300,
       completedDates: ['2026-01-01', '2026-01-02'],
       createdAt: '2026-01-01T00:00:00.000Z',
+      checkInEnabled: true,
     }
 
     expect(dailyTask.type).toBe('daily')
@@ -26,6 +27,7 @@ describe('Task Types', () => {
       currentValue: 5000,
       unit: 'steps',
       createdAt: '2026-01-01T00:00:00.000Z',
+      checkInEnabled: true,
     }
 
     expect(progressTask.type).toBe('progress')
@@ -39,6 +41,7 @@ describe('Task Types', () => {
       title: 'Read TypeScript handbook',
       type: 'one-time',
       createdAt: '2026-01-01T00:00:00.000Z',
+      checkInEnabled: false,
     }
 
     expect(oneTimeTask.type).toBe('one-time')
@@ -52,6 +55,7 @@ describe('Task Types', () => {
       type: 'one-time',
       completedAt: '2026-01-15T10:00:00.000Z',
       createdAt: '2026-01-01T00:00:00.000Z',
+      checkInEnabled: false,
     }
 
     expect(oneTimeTask.completedAt).toBe('2026-01-15T10:00:00.000Z')
@@ -97,6 +101,7 @@ describe('isDailyTaskCompletedToday', () => {
       targetDays: 100,
       completedDates: ['2026-01-14', '2026-01-15'],
       createdAt: '2026-01-01T00:00:00.000Z',
+      checkInEnabled: true,
     }
 
     expect(isDailyTaskCompletedToday(task)).toBeTruthy()
@@ -110,6 +115,7 @@ describe('isDailyTaskCompletedToday', () => {
       targetDays: 100,
       completedDates: ['2026-01-13', '2026-01-14'],
       createdAt: '2026-01-01T00:00:00.000Z',
+      checkInEnabled: true,
     }
 
     expect(isDailyTaskCompletedToday(task)).toBeFalsy()
@@ -123,6 +129,7 @@ describe('isDailyTaskCompletedToday', () => {
       targetDays: 100,
       completedDates: [],
       createdAt: '2026-01-01T00:00:00.000Z',
+      checkInEnabled: true,
     }
 
     expect(isDailyTaskCompletedToday(task)).toBeFalsy()

--- a/src/models/task.ts
+++ b/src/models/task.ts
@@ -8,6 +8,7 @@ export interface BaseTask {
   description?: string
   type: TaskType
   createdAt: string // ISO date
+  checkInEnabled: boolean // Include in daily check-in
 }
 
 // Daily task — complete N days total
@@ -42,6 +43,7 @@ export interface CreateTaskData {
   targetDays?: number // for daily
   targetValue?: number // for progress
   unit?: string // for progress
+  checkInEnabled?: boolean // Include in daily check-in (default: false)
 }
 
 // Check-in result for a single task

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -12,6 +12,10 @@ export const useTaskStore = defineStore('tasks', () => {
 
   function getTasksForCheckIn(): Task[] {
     return activeTasks.value.filter((task) => {
+      // Only include tasks with check-in enabled
+      if (!task.checkInEnabled) {
+        return false
+      }
       // Skip daily tasks that were already completed today
       if (isDailyTask(task) && isDailyTaskCompletedToday(task)) {
         return false

--- a/src/test-utils/api-mocks.ts
+++ b/src/test-utils/api-mocks.ts
@@ -42,6 +42,7 @@ export function createMockOneTimeTask(overrides: Partial<OneTimeTask> = {}): One
     title: 'Test One-Time Task',
     type: 'one-time',
     createdAt: '2026-01-01',
+    checkInEnabled: true,
     ...overrides,
   }
 }
@@ -54,6 +55,7 @@ export function createMockDailyTask(overrides: Partial<DailyTask> = {}): DailyTa
     targetDays: 100,
     completedDates: [],
     createdAt: '2026-01-01',
+    checkInEnabled: true,
     ...overrides,
   }
 }
@@ -67,6 +69,7 @@ export function createMockProgressTask(overrides: Partial<ProgressTask> = {}): P
     currentValue: 0,
     unit: 'units',
     createdAt: '2026-01-01',
+    checkInEnabled: true,
     ...overrides,
   }
 }
@@ -78,6 +81,7 @@ function createTaskFromData(data: CreateTaskData): Task {
     title: data.title,
     description: data.description,
     createdAt: TEST_DATE,
+    checkInEnabled: data.checkInEnabled ?? false,
   }
 
   switch (data.type) {

--- a/src/views/UserProfileView.vue
+++ b/src/views/UserProfileView.vue
@@ -1008,7 +1008,7 @@
     height: 56px;
     border-radius: 50%;
     border: none;
-    padding: 0 0 6px;
+    padding: 0;
     background: var(--color-primary);
     color: white;
     font-size: 2.5rem;

--- a/src/views/__tests__/ControlView.browser.test.ts
+++ b/src/views/__tests__/ControlView.browser.test.ts
@@ -48,6 +48,7 @@ describe('ControlView - Browser Tests', () => {
       title: 'Test task',
       type: 'one-time',
       createdAt: '2026-01-01',
+      checkInEnabled: true,
     }
     setMockTasks([task])
 
@@ -117,6 +118,7 @@ describe('ControlView - Browser Tests', () => {
       title: 'Test No button',
       type: 'one-time',
       createdAt: '2026-01-01',
+      checkInEnabled: true,
     }
     setMockTasks([task])
 
@@ -174,12 +176,14 @@ describe('ControlView - Browser Tests', () => {
       title: 'First task',
       type: 'one-time',
       createdAt: '2026-01-01',
+      checkInEnabled: true,
     }
     const task2: OneTimeTask = {
       id: 'test-task-4',
       title: 'Second task',
       type: 'one-time',
       createdAt: '2026-01-02',
+      checkInEnabled: true,
     }
     setMockTasks([task1, task2])
 
@@ -256,6 +260,7 @@ describe('ControlView - Browser Tests', () => {
         targetDays: 100,
         completedDates: ['2026-01-01', '2026-01-02'],
         createdAt: '2026-01-01',
+        checkInEnabled: true,
       }
       setMockTasks([task])
 
@@ -306,6 +311,7 @@ describe('ControlView - Browser Tests', () => {
         targetDays: 50,
         completedDates: ['2026-01-01'],
         createdAt: '2026-01-01',
+        checkInEnabled: true,
       }
       setMockTasks([task])
 
@@ -350,6 +356,7 @@ describe('ControlView - Browser Tests', () => {
         targetDays: 100,
         completedDates: [TEST_DATE], // Already marked today
         createdAt: '2026-01-01',
+        checkInEnabled: true,
       }
       setMockTasks([task])
 
@@ -398,6 +405,7 @@ describe('ControlView - Browser Tests', () => {
         currentValue: 500_000,
         unit: 'steps',
         createdAt: '2026-01-01',
+        checkInEnabled: true,
       }
       setMockTasks([task])
 
@@ -449,6 +457,7 @@ describe('ControlView - Browser Tests', () => {
         currentValue: 50_000,
         unit: '$',
         createdAt: '2026-01-01',
+        checkInEnabled: true,
       }
       setMockTasks([task])
 
@@ -516,6 +525,7 @@ describe('ControlView - Browser Tests', () => {
         currentValue: 200,
         unit: 'km',
         createdAt: '2026-01-01',
+        checkInEnabled: true,
       }
       setMockTasks([task])
 
@@ -574,6 +584,7 @@ describe('ControlView - Browser Tests', () => {
         targetDays: 100,
         completedDates: [],
         createdAt: '2026-01-01',
+        checkInEnabled: true,
       }
 
       const progressTask: ProgressTask = {
@@ -584,6 +595,7 @@ describe('ControlView - Browser Tests', () => {
         currentValue: 100,
         unit: 'points',
         createdAt: '2026-01-01',
+        checkInEnabled: true,
       }
 
       const oneTimeTask: OneTimeTask = {
@@ -591,6 +603,7 @@ describe('ControlView - Browser Tests', () => {
         title: 'One-time task',
         type: 'one-time',
         createdAt: '2026-01-01',
+        checkInEnabled: true,
       }
 
       setMockTasks([dailyTask, progressTask, oneTimeTask])

--- a/worker/db/schema.ts
+++ b/worker/db/schema.ts
@@ -61,6 +61,9 @@ export const tasks = sqliteTable(
 
     // One-time task fields
     completedAt: text('completed_at'),
+
+    // Check-in control
+    checkInEnabled: integer('check_in_enabled', { mode: 'boolean' }).notNull().default(false),
   },
   (table) => [index('tasks_user_id_idx').on(table.userId)]
 )

--- a/worker/db/task-queries.ts
+++ b/worker/db/task-queries.ts
@@ -16,6 +16,7 @@ function rowToTask(row: TaskRow, completedDates: string[] = []): Task {
     title: row.title,
     description: row.description ?? undefined,
     createdAt: row.createdAt,
+    checkInEnabled: row.checkInEnabled ?? false,
   }
 
   switch (row.type) {
@@ -116,6 +117,7 @@ export async function createTask(db: Database, userId: string, data: CreateTaskD
     type: data.type as TaskType,
     createdAt,
     isArchived: false,
+    checkInEnabled: data.checkInEnabled ?? false,
   }
 
   switch (data.type) {
@@ -182,6 +184,7 @@ export async function updateTask(db: Database, userId: string, task: Task): Prom
   const baseUpdate = {
     title: task.title,
     description: task.description ?? null,
+    checkInEnabled: task.checkInEnabled,
   }
 
   const ownershipCondition = and(eq(tasks.id, task.id), eq(tasks.userId, userId))

--- a/worker/schemas.ts
+++ b/worker/schemas.ts
@@ -9,6 +9,7 @@ export const createTaskSchema = valibot.object({
   targetDays: valibot.optional(valibot.number()),
   targetValue: valibot.optional(valibot.number()),
   unit: valibot.optional(valibot.string()),
+  checkInEnabled: valibot.optional(valibot.boolean()),
 })
 
 export const updateTaskSchema = valibot.object({
@@ -17,6 +18,7 @@ export const updateTaskSchema = valibot.object({
   description: valibot.optional(valibot.string()),
   type: taskTypeSchema,
   createdAt: valibot.string(),
+  checkInEnabled: valibot.boolean(),
   // Daily
   targetDays: valibot.optional(valibot.number()),
   completedDates: valibot.optional(valibot.array(valibot.string())),

--- a/worker/task-routes.ts
+++ b/worker/task-routes.ts
@@ -101,6 +101,7 @@ taskRoutes.put('/:id', vValidator('json', updateTaskSchema), async (context) => 
     title: data.title,
     description: data.description,
     createdAt: data.createdAt,
+    checkInEnabled: data.checkInEnabled,
   }
 
   const task: Task = (() => {


### PR DESCRIPTION
## Summary
This PR adds a `checkInEnabled` flag to tasks, allowing users to choose which tasks should appear in the daily check-in wizard.

## Changes
- ✨ Added `checkInEnabled` field to the `Task` model and database schema.
- ✨ Added a checkbox in `TaskForm` and `TaskCard` (edit mode) to toggle this flag.
- 🗄️ Added a Drizzle migration (`0005_equal-miek`) to add the `check_in_enabled` column to the `tasks` table.
- 🔍 Updated `task-store.ts` to filter tasks in the check-in wizard based on this flag.
- 🌐 Added translations for the new field in English and Russian.
- ✅ Updated unit tests and browser tests to include the new field.
- 🎨 Fixed minor button padding issue in `UserProfileView.vue`.

## Verification Results
- ✅ `npm run lint` passed.
- ✅ `npm run test` (unit tests) passed.
- ✅ `npm run test:browser` (Playwright tests) passed.
- ✅ `npm run build` succeeded.