### PR TITLE
feat: allow editing one-time task completion status

### DIFF
--- a/src/components/TaskCard.vue
+++ b/src/components/TaskCard.vue
@@ -150,6 +150,31 @@
               </div>
             </template>
 
+            <!-- One-time task fields -->
+            <template v-if="isOneTimeTask(task)">
+              <div :class="$style.formGroup">
+                <label :class="$style.checkboxLabel">
+                  <input
+                    v-model="editForm.isCompleted"
+                    type="checkbox"
+                    :class="$style.checkbox"
+                  />
+                  <span>{{ $t('taskCard.markCompleted') }}</span>
+                </label>
+              </div>
+
+              <div v-if="editForm.isCompleted" :class="$style.formGroup">
+                <label :class="$style.label">{{ $t('taskCard.completionDate') }}</label>
+                <input
+                  v-model="editForm.completedAt"
+                  :class="$style.input"
+                  type="date"
+                  :max="todayDate"
+                  required
+                />
+              </div>
+            </template>
+
             <!-- Check-in control (common for all task types) -->
             <div :class="$style.checkInField">
               <label :class="$style.checkboxLabel">
@@ -216,6 +241,9 @@
     completedDates: [] as string[],
     newDate: '',
     checkInEnabled: false,
+    // One-time task fields
+    isCompleted: false,
+    completedAt: '',
   })
 
   const progress = computed(() => getTaskProgress(props.task))
@@ -303,6 +331,11 @@
       editForm.targetValue = props.task.targetValue
       editForm.unit = props.task.unit
     }
+
+    if (isOneTimeTask(props.task)) {
+      editForm.isCompleted = Boolean(props.task.completedAt)
+      editForm.completedAt = props.task.completedAt ?? todayDate.value ?? ''
+    }
   }
 
   function openEditModal() {
@@ -341,12 +374,13 @@
         unit: editForm.unit.trim(),
         checkInEnabled: editForm.checkInEnabled,
       } satisfies ProgressTask
-    } else {
+    } else if (isOneTimeTask(props.task)) {
       updatedTask = {
         ...props.task,
         title: editForm.title.trim(),
         description: editForm.description.trim() || undefined,
         checkInEnabled: editForm.checkInEnabled,
+        completedAt: editForm.isCompleted ? editForm.completedAt : undefined,
       }
     }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -47,6 +47,8 @@ const enLocale = {
     oneTimeLabel: '✅ One-time',
     completed: 'Completed ✓',
     notCompleted: 'Not completed',
+    markCompleted: 'Mark as completed',
+    completionDate: 'Completion date',
     goalDays: 'Goal (days)',
     completedDays: 'Completed days',
     noCompletedDays: 'No completed days',

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -47,6 +47,8 @@ const ruLocale = {
     oneTimeLabel: '✅ Разовая',
     completed: 'Выполнено ✓',
     notCompleted: 'Не выполнено',
+    markCompleted: 'Отметить как выполненную',
+    completionDate: 'Дата выполнения',
     goalDays: 'Цель (дней)',
     completedDays: 'Выполненные дни',
     noCompletedDays: 'Нет выполненных дней',


### PR DESCRIPTION
## Summary
This PR adds the ability to mark one-time tasks as completed or uncompleted directly from the task edit modal.

## Changes
- Added `isCompleted` and `completedAt` fields to the edit form in `TaskCard.vue`.
- Added a checkbox to toggle completion status for one-time tasks.
- Added a date picker to select the completion date when a task is marked as completed.
- Updated `initEditForm` to populate completion status from the task data.
- Updated `saveChanges` to include `completedAt` in the updated task object.
- Added translation keys for "Mark as completed" and "Completion date" in English and Russian locales.

## Motivation
Previously, one-time tasks could only be marked as completed during the daily check-in flow. This change provides more flexibility by allowing users to manage completion status manually during editing.