### PR TITLE
style: move scrollbar to browser edge on wide screens

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,10 +3,12 @@
     <ErrorBanner :message="taskStore.error" @dismiss="taskStore.clearError()" />
 
     <main :class="$style.main">
-      <RouterView />
+      <div :class="$style.content">
+        <RouterView />
+      </div>
     </main>
 
-    <AppFooter />
+    <AppFooter :class="$style.content" />
   </div>
 </template>
 
@@ -25,13 +27,17 @@
     flex-direction: column;
     height: 100vh;
     height: 100dvh;
-    max-width: var(--content-max-width);
-    margin: 0 auto;
   }
 
   .main {
     flex: 1;
     overflow-y: auto;
+  }
+
+  .content {
+    max-width: var(--content-max-width);
+    margin: 0 auto;
+    width: 100%;
   }
 </style>
 


### PR DESCRIPTION
## 🎨 Layout Improvements

- Moved the scrollbar from the centered content container to the browser window edge.
- Added a `.content` wrapper inside the scrollable area to maintain the 600px max-width constraint.
- Applied the same centering logic to the `AppFooter`.

This change improves the user experience on wide screens by making the scrollbar feel more native and less intrusive.