### PR TITLE
feat: add task sorting by update date and check-in status

### DIFF
--- a/drizzle/20260101184437_steady_deathbird/migration.sql
+++ b/drizzle/20260101184437_steady_deathbird/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tasks` ADD `updated_at` text NOT NULL;

--- a/drizzle/20260101184437_steady_deathbird/snapshot.json
+++ b/drizzle/20260101184437_steady_deathbird/snapshot.json
@@ -1,0 +1,447 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "7df7ef6a-bcdf-4ae2-af86-b6d64f45b4dd",
+  "prevIds": [
+    "2ce9575b-1e70-4c3e-84b5-e3f030e3f13a"
+  ],
+  "ddl": [
+    {
+      "name": "daily_completions",
+      "entityType": "tables"
+    },
+    {
+      "name": "sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "tasks",
+      "entityType": "tables"
+    },
+    {
+      "name": "users",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "daily_completions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "task_id",
+      "entityType": "columns",
+      "table": "daily_completions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_date",
+      "entityType": "columns",
+      "table": "daily_completions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_days",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_value",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "current_value",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "unit",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "check_in_enabled",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "twitch_id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "avatar_url",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'en'",
+      "generated": null,
+      "name": "language",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "columns": [
+        "task_id"
+      ],
+      "tableTo": "tasks",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_daily_completions_task_id_tasks_id_fk",
+      "entityType": "fks",
+      "table": "daily_completions"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sessions_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_tasks_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "tasks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "daily_completions_pk",
+      "table": "daily_completions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pk",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "tasks_pk",
+      "table": "tasks",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pk",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "task_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "daily_completions_task_id_idx",
+      "entityType": "indexes",
+      "table": "daily_completions"
+    },
+    {
+      "columns": [
+        {
+          "value": "task_id",
+          "isExpression": false
+        },
+        {
+          "value": "completed_date",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "daily_completions_task_date_idx",
+      "entityType": "indexes",
+      "table": "daily_completions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "sessions_user_id_idx",
+      "entityType": "indexes",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "tasks_user_id_idx",
+      "entityType": "indexes",
+      "table": "tasks"
+    },
+    {
+      "columns": [
+        "twitch_id"
+      ],
+      "nameExplicit": false,
+      "name": "users_twitch_id_unique",
+      "entityType": "uniques",
+      "table": "users"
+    }
+  ],
+  "renames": []
+}

--- a/drizzle/migrations/.converted
+++ b/drizzle/migrations/.converted
@@ -3,3 +3,4 @@
 20251230202707_clean_gravity
 20251230220014_mute_iron_lad
 20251231180641_equal_miek
+20260101184437_steady_deathbird

--- a/drizzle/migrations/0006_steady-deathbird.sql
+++ b/drizzle/migrations/0006_steady-deathbird.sql
@@ -1,0 +1,7 @@
+-- Add updated_at column with default value for existing rows
+-- For existing rows, set to '2026-01-01T00:00:00.000Z' as placeholder
+-- New rows will have proper timestamp from application code
+ALTER TABLE `tasks` ADD `updated_at` text NOT NULL DEFAULT '2026-01-01T00:00:00.000Z';
+
+-- Update existing rows to use created_at as initial updated_at value
+UPDATE `tasks` SET `updated_at` = `created_at` WHERE `updated_at` = '2026-01-01T00:00:00.000Z';

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "vue-router": "4.6.4"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20251231.0",
+    "@cloudflare/workers-types": "4.20260101.0",
     "@hono/valibot-validator": "0.6.1",
     "@types/node": "25.0.3",
     "@vitejs/plugin-vue": "6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 5.0.0(vue@3.5.26(typescript@5.9.3))
       drizzle-orm:
         specifier: 1.0.0-beta.8-734e789
-        version: 1.0.0-beta.8-734e789(@cloudflare/workers-types@4.20251231.0)(@types/mssql@9.1.8)(mssql@11.0.1)
+        version: 1.0.0-beta.8-734e789(@cloudflare/workers-types@4.20260101.0)(@types/mssql@9.1.8)(mssql@11.0.1)
       hono:
         specifier: 4.11.3
         version: 4.11.3
@@ -40,8 +40,8 @@ importers:
         version: 4.6.4(vue@3.5.26(typescript@5.9.3))
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: 4.20251231.0
-        version: 4.20251231.0
+        specifier: 4.20260101.0
+        version: 4.20260101.0
       '@hono/valibot-validator':
         specifier: 0.6.1
         version: 0.6.1(hono@4.11.3)(valibot@1.2.0(typescript@5.9.3))
@@ -101,7 +101,7 @@ importers:
         version: 3.2.1(typescript@5.9.3)
       wrangler:
         specifier: 4.54.0
-        version: 4.54.0(@cloudflare/workers-types@4.20251231.0)
+        version: 4.54.0(@cloudflare/workers-types@4.20260101.0)
 
 packages:
 
@@ -238,8 +238,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20251231.0':
-    resolution: {integrity: sha512-XOP7h2y9Nu3ECuZM9S7w3g4GSliTgj6SEEkYj6G6d3TEQtOiV/cHXuI/fKiLj8Z9+qJK/RLLcKkX14NxajrXCw==}
+  '@cloudflare/workers-types@4.20260101.0':
+    resolution: {integrity: sha512-C28o4U1T4dPe8avLv1xMQ4MtSE6G4skbVA3VfVZIrpTqklvO+homKB1uFEtNbuZlaKg+Znv8sjmGQUInTH17gA==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -3227,7 +3227,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20251210.0':
     optional: true
 
-  '@cloudflare/workers-types@4.20251231.0': {}
+  '@cloudflare/workers-types@4.20260101.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -4413,12 +4413,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@1.0.0-beta.8-734e789(@cloudflare/workers-types@4.20251231.0)(@types/mssql@9.1.8)(mssql@11.0.1):
+  drizzle-orm@1.0.0-beta.8-734e789(@cloudflare/workers-types@4.20260101.0)(@types/mssql@9.1.8)(mssql@11.0.1):
     dependencies:
       '@types/mssql': 9.1.8
       mssql: 11.0.1
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20251231.0
+      '@cloudflare/workers-types': 4.20260101.0
 
   eastasianwidth@0.2.0: {}
 
@@ -5625,7 +5625,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20251210.0
       '@cloudflare/workerd-windows-64': 1.20251210.0
 
-  wrangler@4.54.0(@cloudflare/workers-types@4.20251231.0):
+  wrangler@4.54.0(@cloudflare/workers-types@4.20260101.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.1
       '@cloudflare/unenv-preset': 2.7.13(unenv@2.0.0-rc.24)(workerd@1.20251210.0)
@@ -5636,7 +5636,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20251210.0
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20251231.0
+      '@cloudflare/workers-types': 4.20260101.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/src/api/task-api.ts
+++ b/src/api/task-api.ts
@@ -28,7 +28,9 @@ export async function createTask(data: CreateTaskData): Promise<Task> {
 
 // Update existing task
 export async function updateTask(task: Task): Promise<Task> {
-  return api.put(`tasks/${task.id}`, { json: task }).json<Task>()
+  // Strip timestamp fields - server will generate them
+  const { createdAt: _createdAt, updatedAt: _updatedAt, ...taskData } = task
+  return api.put(`tasks/${task.id}`, { json: taskData }).json<Task>()
 }
 
 // Delete task

--- a/src/models/__tests__/task.test.ts
+++ b/src/models/__tests__/task.test.ts
@@ -19,6 +19,7 @@ describe('Task Types', () => {
       targetDays: 300,
       completedDates: ['2026-01-01', '2026-01-02'],
       createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
       checkInEnabled: true,
     }
 
@@ -36,6 +37,7 @@ describe('Task Types', () => {
       currentValue: 5000,
       unit: 'steps',
       createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
       checkInEnabled: true,
     }
 
@@ -50,6 +52,7 @@ describe('Task Types', () => {
       title: 'Read TypeScript handbook',
       type: 'one-time',
       createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
       checkInEnabled: false,
     }
 
@@ -64,6 +67,7 @@ describe('Task Types', () => {
       type: 'one-time',
       completedAt: '2026-01-15T10:00:00.000Z',
       createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
       checkInEnabled: false,
     }
 
@@ -110,6 +114,7 @@ describe('isDailyTaskCompletedToday', () => {
       targetDays: 100,
       completedDates: ['2026-01-14', '2026-01-15'],
       createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
       checkInEnabled: true,
     }
 
@@ -124,6 +129,7 @@ describe('isDailyTaskCompletedToday', () => {
       targetDays: 100,
       completedDates: ['2026-01-13', '2026-01-14'],
       createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
       checkInEnabled: true,
     }
 
@@ -138,6 +144,7 @@ describe('isDailyTaskCompletedToday', () => {
       targetDays: 100,
       completedDates: [],
       createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
       checkInEnabled: true,
     }
 
@@ -159,6 +166,7 @@ describe('getGlobalProgress', () => {
         targetDays: 10,
         completedDates: Array.from({ length: 10 }, (_unused, index) => `2026-01-0${index + 1}`),
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: true,
       },
       {
@@ -169,6 +177,7 @@ describe('getGlobalProgress', () => {
         currentValue: 100,
         unit: 'pages',
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: true,
       },
       {
@@ -177,6 +186,7 @@ describe('getGlobalProgress', () => {
         type: 'one-time',
         completedAt: '2026-01-15T00:00:00.000Z',
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: false,
       },
     ]
@@ -193,6 +203,7 @@ describe('getGlobalProgress', () => {
         targetDays: 10,
         completedDates: [],
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: true,
       },
       {
@@ -203,6 +214,7 @@ describe('getGlobalProgress', () => {
         currentValue: 0,
         unit: 'pages',
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: true,
       },
       {
@@ -210,6 +222,7 @@ describe('getGlobalProgress', () => {
         title: 'One-time task',
         type: 'one-time',
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: false,
       },
     ]
@@ -226,6 +239,7 @@ describe('getGlobalProgress', () => {
         targetDays: 10,
         completedDates: ['2026-01-01', '2026-01-02', '2026-01-03', '2026-01-04', '2026-01-05'], // 50%
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: true,
       },
       {
@@ -236,6 +250,7 @@ describe('getGlobalProgress', () => {
         currentValue: 50, // 50%
         unit: 'pages',
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: true,
       },
     ]
@@ -252,6 +267,7 @@ describe('getGlobalProgress', () => {
         targetDays: 10,
         completedDates: Array.from({ length: 10 }, (_unused, index) => `2026-01-${String(index + 1).padStart(2, '0')}`), // 100%
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: true,
       },
       {
@@ -262,6 +278,7 @@ describe('getGlobalProgress', () => {
         currentValue: 0, // 0%
         unit: 'pages',
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: true,
       },
     ]
@@ -279,6 +296,7 @@ describe('getGlobalProgress', () => {
         currentValue: 150, // should be capped at 100%
         unit: 'pages',
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: true,
       },
     ]
@@ -296,6 +314,7 @@ describe('getTaskProgress - division by zero edge cases', () => {
       targetDays: 0,
       completedDates: [],
       createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
       checkInEnabled: true,
     }
 
@@ -311,6 +330,7 @@ describe('getTaskProgress - division by zero edge cases', () => {
       currentValue: 0,
       unit: 'steps',
       createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
       checkInEnabled: true,
     }
 
@@ -326,6 +346,7 @@ describe('getTaskProgress - division by zero edge cases', () => {
       currentValue: 100,
       unit: 'pages',
       createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
       checkInEnabled: true,
     }
 
@@ -341,6 +362,7 @@ describe('getTaskProgress - division by zero edge cases', () => {
         targetDays: 0,
         completedDates: [],
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: true,
       },
       {
@@ -351,6 +373,7 @@ describe('getTaskProgress - division by zero edge cases', () => {
         currentValue: 0,
         unit: 'steps',
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: true,
       },
       {
@@ -361,6 +384,7 @@ describe('getTaskProgress - division by zero edge cases', () => {
         currentValue: 50,
         unit: 'pages',
         createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
         checkInEnabled: true,
       },
     ]

--- a/src/models/task.ts
+++ b/src/models/task.ts
@@ -8,6 +8,7 @@ export interface BaseTask {
   description?: string
   type: TaskType
   createdAt: string // ISO date
+  updatedAt: string // ISO date
   checkInEnabled: boolean // Include in daily check-in
 }
 

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -11,6 +11,33 @@ export const useTaskStore = defineStore('tasks', () => {
   const activeTasks = computed(() => tasks.value.filter((t) => !isTaskCompleted(t)))
   const completedTasks = computed(() => tasks.value.filter((t) => isTaskCompleted(t)))
 
+  // Sorted tasks with priority: check-in enabled → recently updated
+  const sortedActiveTasks = computed(() =>
+    activeTasks.value.toSorted((taskA, taskB) => {
+      // Priority 1: Tasks that require check-in
+      if (taskA.checkInEnabled && !taskB.checkInEnabled) {
+        return -1
+      }
+      if (!taskA.checkInEnabled && taskB.checkInEnabled) {
+        return 1
+      }
+
+      // Priority 2: Recently updated (desc)
+      const aUpdated = new Date(taskA.updatedAt).getTime()
+      const bUpdated = new Date(taskB.updatedAt).getTime()
+      return bUpdated - aUpdated
+    })
+  )
+
+  const sortedCompletedTasks = computed(() =>
+    // Completed tasks: sort by update date (most recent first)
+    completedTasks.value.toSorted((taskA, taskB) => {
+      const aUpdated = new Date(taskA.updatedAt).getTime()
+      const bUpdated = new Date(taskB.updatedAt).getTime()
+      return bUpdated - aUpdated
+    })
+  )
+
   function getTasksForCheckIn(): Task[] {
     return activeTasks.value.filter((task) => {
       // Only include tasks with check-in enabled
@@ -119,6 +146,8 @@ export const useTaskStore = defineStore('tasks', () => {
     error: errorMessage,
     activeTasks,
     completedTasks,
+    sortedActiveTasks,
+    sortedCompletedTasks,
     getTasksForCheckIn,
     fetchTasks,
     addTask,

--- a/src/test-utils/api-mocks.ts
+++ b/src/test-utils/api-mocks.ts
@@ -42,6 +42,7 @@ export function createMockOneTimeTask(overrides: Partial<OneTimeTask> = {}): One
     title: 'Test One-Time Task',
     type: 'one-time',
     createdAt: '2026-01-01',
+    updatedAt: overrides.updatedAt ?? '2026-01-01',
     checkInEnabled: true,
     ...overrides,
   }
@@ -55,6 +56,7 @@ export function createMockDailyTask(overrides: Partial<DailyTask> = {}): DailyTa
     targetDays: 100,
     completedDates: [],
     createdAt: '2026-01-01',
+    updatedAt: overrides.updatedAt ?? '2026-01-01',
     checkInEnabled: true,
     ...overrides,
   }
@@ -69,6 +71,7 @@ export function createMockProgressTask(overrides: Partial<ProgressTask> = {}): P
     currentValue: 0,
     unit: 'units',
     createdAt: '2026-01-01',
+    updatedAt: overrides.updatedAt ?? '2026-01-01',
     checkInEnabled: true,
     ...overrides,
   }
@@ -81,6 +84,7 @@ function createTaskFromData(data: CreateTaskData): Task {
     title: data.title,
     description: data.description,
     createdAt: TEST_DATE,
+    updatedAt: TEST_DATE,
     checkInEnabled: data.checkInEnabled ?? false,
   }
 
@@ -181,6 +185,7 @@ export const handlers = [
           const dailyTask = task as DailyTask
           if (!dailyTask.completedDates.includes(TEST_DATE)) {
             dailyTask.completedDates.push(TEST_DATE)
+            dailyTask.updatedAt = TEST_DATE
           }
           break
         }
@@ -188,12 +193,14 @@ export const handlers = [
           const progressTask = task as ProgressTask
           if (value !== undefined && value > 0) {
             progressTask.currentValue += value
+            progressTask.updatedAt = TEST_DATE
           }
           break
         }
         case 'one-time': {
           const oneTimeTask = task as OneTimeTask
           oneTimeTask.completedAt = TEST_DATE
+          oneTimeTask.updatedAt = TEST_DATE
           break
         }
       }

--- a/src/views/__tests__/ControlView.browser.test.ts
+++ b/src/views/__tests__/ControlView.browser.test.ts
@@ -48,6 +48,7 @@ describe('ControlView - Browser Tests', () => {
       title: 'Test task',
       type: 'one-time',
       createdAt: '2026-01-01',
+      updatedAt: '2026-01-01',
       checkInEnabled: true,
     }
     setMockTasks([task])
@@ -118,6 +119,7 @@ describe('ControlView - Browser Tests', () => {
       title: 'Test No button',
       type: 'one-time',
       createdAt: '2026-01-01',
+      updatedAt: '2026-01-01',
       checkInEnabled: true,
     }
     setMockTasks([task])
@@ -176,6 +178,7 @@ describe('ControlView - Browser Tests', () => {
       title: 'First task',
       type: 'one-time',
       createdAt: '2026-01-01',
+      updatedAt: '2026-01-01',
       checkInEnabled: true,
     }
     const task2: OneTimeTask = {
@@ -183,6 +186,7 @@ describe('ControlView - Browser Tests', () => {
       title: 'Second task',
       type: 'one-time',
       createdAt: '2026-01-02',
+      updatedAt: '2026-01-02',
       checkInEnabled: true,
     }
     setMockTasks([task1, task2])
@@ -258,8 +262,9 @@ describe('ControlView - Browser Tests', () => {
         title: 'Run every day',
         type: 'daily',
         targetDays: 100,
-        completedDates: ['2026-01-01', '2026-01-02'],
+        completedDates: ['2025-01-01', '2025-01-02'],
         createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
         checkInEnabled: true,
       }
       setMockTasks([task])
@@ -309,8 +314,9 @@ describe('ControlView - Browser Tests', () => {
         title: 'Read a book',
         type: 'daily',
         targetDays: 50,
-        completedDates: ['2026-01-01'],
+        completedDates: ['2025-01-01'],
         createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
         checkInEnabled: true,
       }
       setMockTasks([task])
@@ -345,7 +351,7 @@ describe('ControlView - Browser Tests', () => {
       const tasks = getMockTasksStorage() as DailyTask[]
       const unchangedTask = tasks.find((t) => t.id === 'daily-2')
 
-      expect(unchangedTask?.completedDates).toEqual(['2026-01-01'])
+      expect(unchangedTask?.completedDates).toEqual(['2025-01-01'])
     })
 
     it('should prevent duplicate date when checking in same day twice', async () => {
@@ -356,6 +362,7 @@ describe('ControlView - Browser Tests', () => {
         targetDays: 100,
         completedDates: [TEST_DATE], // Already marked today
         createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
         checkInEnabled: true,
       }
       setMockTasks([task])
@@ -405,6 +412,7 @@ describe('ControlView - Browser Tests', () => {
         currentValue: 500_000,
         unit: 'steps',
         createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
         checkInEnabled: true,
       }
       setMockTasks([task])
@@ -457,6 +465,7 @@ describe('ControlView - Browser Tests', () => {
         currentValue: 50_000,
         unit: '$',
         createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
         checkInEnabled: true,
       }
       setMockTasks([task])
@@ -525,6 +534,7 @@ describe('ControlView - Browser Tests', () => {
         currentValue: 200,
         unit: 'km',
         createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
         checkInEnabled: true,
       }
       setMockTasks([task])
@@ -584,6 +594,7 @@ describe('ControlView - Browser Tests', () => {
         targetDays: 100,
         completedDates: [],
         createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
         checkInEnabled: true,
       }
 
@@ -595,6 +606,7 @@ describe('ControlView - Browser Tests', () => {
         currentValue: 100,
         unit: 'points',
         createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
         checkInEnabled: true,
       }
 
@@ -603,6 +615,7 @@ describe('ControlView - Browser Tests', () => {
         title: 'One-time task',
         type: 'one-time',
         createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
         checkInEnabled: true,
       }
 

--- a/worker/db/schema.ts
+++ b/worker/db/schema.ts
@@ -50,6 +50,7 @@ export const tasks = sqliteTable(
     description: text('description'),
     type: text('type', { enum: taskTypes }).notNull(),
     createdAt: text('created_at').notNull(), // ISO timestamp
+    updatedAt: text('updated_at').notNull(), // ISO timestamp
 
     // Daily task fields
     targetDays: integer('target_days'),

--- a/worker/schemas.ts
+++ b/worker/schemas.ts
@@ -17,7 +17,6 @@ export const updateTaskSchema = valibot.object({
   title: valibot.pipe(valibot.string(), valibot.minLength(1)),
   description: valibot.optional(valibot.string()),
   type: taskTypeSchema,
-  createdAt: valibot.string(),
   checkInEnabled: valibot.boolean(),
   // Daily
   targetDays: valibot.optional(valibot.number()),

--- a/worker/task-routes.ts
+++ b/worker/task-routes.ts
@@ -96,11 +96,14 @@ taskRoutes.put('/:id', vValidator('json', updateTaskSchema), async (context) => 
   }
 
   // Reconstruct the Task union type from the flat schema
+  // Note: timestamps are server-controlled, not from client
   const baseTask = {
     id: data.id,
     title: data.title,
     description: data.description,
-    createdAt: data.createdAt,
+    // Timestamps will be set by updateTask, use placeholders for type safety
+    createdAt: '',
+    updatedAt: '',
     checkInEnabled: data.checkInEnabled,
   }
 


### PR DESCRIPTION
## Summary
This PR introduces task sorting based on the `updatedAt` timestamp and check-in status. Tasks that require check-in are prioritized, followed by the most recently updated tasks.

## Changes
- **Database**: Added `updated_at` column to the `tasks` table with a migration.
- **Models**: Added `updatedAt` field to the `Task` interface.
- **Store**: Implemented `sortedActiveTasks` and `sortedCompletedTasks` computed properties in `task-store.ts`.
- **Backend**: Updated `recordCheckIn`, `createTask`, and `updateTask` to refresh the `updatedAt` timestamp.
- **Frontend**: Updated `UserProfileView.vue` to use the new sorted task lists.
- **Tests**: Updated unit and browser tests to include the `updatedAt` field and verified sorting logic.
- **Dependencies**: Updated `@cloudflare/workers-types`.

## Motivation
Improving the user experience by ensuring that tasks requiring immediate attention (check-ins) are easily accessible and that the most recently active tasks are shown first.