### PR TITLE
feat(pwa): exclude /api routes from navigation fallback

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
         enabled: true
       },
 
+      workbox: {
+        navigateFallbackDenylist: [/^\/api\/.*/u]
+      },
+
       registerType: 'prompt',
       injectRegister: null,
 

--- a/worker/utils.ts
+++ b/worker/utils.ts
@@ -3,16 +3,16 @@ import type { Context } from 'hono'
 /**
  * Get the base URL for OAuth redirects.
  * Uses REDIRECT_BASE_URL from environment if set, otherwise extracts origin from the current request.
- * 
+ *
  * @param context - Hono context with environment bindings
  * @returns The base URL (origin) to use for constructing redirect URIs
  * @throws {Error} If the request URL is invalid when REDIRECT_BASE_URL is not set
  */
 export function getRedirectBaseUrl(context: Context): string {
-  if (context.env.REDIRECT_BASE_URL) {
+  if (context.env.REDIRECT_BASE_URL !== undefined) {
     return context.env.REDIRECT_BASE_URL
   }
-  
+
   try {
     return new URL(context.req.url).origin
   } catch (error) {
@@ -23,14 +23,14 @@ export function getRedirectBaseUrl(context: Context): string {
 /**
  * Get the Twitch OAuth callback URL.
  * Constructs the full callback URL using the redirect base URL.
- * 
+ *
  * @param context - Hono context with environment bindings
  * @returns The full Twitch callback URL
  * @throws {Error} If the base URL is invalid or cannot be constructed
  */
 export function getTwitchCallbackUrl(context: Context): string {
   const baseUrl = getRedirectBaseUrl(context)
-  
+
   try {
     return new URL('/api/auth/twitch/callback', baseUrl).toString()
   } catch (error) {


### PR DESCRIPTION
## Summary
This PR excludes `/api` routes from the PWA navigation fallback to prevent the service worker from intercepting API requests and serving the app shell instead. It also fixes a lint error in the worker utilities.

## Changes
- ✨ Added \`navigateFallbackDenylist: [/^\/api\/.*/u]\` to Workbox configuration in \`vite.config.ts\`.
- 🐛 Fixed a lint error in \`worker/utils.ts\` by adding an explicit type check for \`REDIRECT_BASE_URL\`.

## Verification
- [x] \`pnpm run lint\` passes.
- [x] \`pnpm run test\` passes.
- [x] \`pnpm run build\` succeeds.
- [x] \`pnpm run test:browser\` passes.